### PR TITLE
Use ducks pattern

### DIFF
--- a/src/components/ItemCreator/index.js
+++ b/src/components/ItemCreator/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { addItem } from '../../logic/actions';
+import { addItem } from '../../logic/todos';
 import './styles.css';
 
 export const ItemCreator = ({ onAdd }) => {

--- a/src/logic/actions.js
+++ b/src/logic/actions.js
@@ -1,5 +1,0 @@
-import { ADD_ITEM } from './constants';
-
-export const addItem = content => {
-  return { type: ADD_ITEM, content };
-};

--- a/src/logic/constants.js
+++ b/src/logic/constants.js
@@ -1,1 +1,0 @@
-export const ADD_ITEM = 'qgo/assessment/ADD_ITEM';

--- a/src/logic/tests/todos.test.js
+++ b/src/logic/tests/todos.test.js
@@ -1,5 +1,4 @@
-import reducer, { initialState } from '../reducer';
-import { addItem } from '../actions';
+import reducer, { initialState, addItem } from '../todos';
 
 describe('reducer', () => {
   it('should return state for unknown action', () => {

--- a/src/logic/todos.js
+++ b/src/logic/todos.js
@@ -1,4 +1,8 @@
-import { ADD_ITEM } from './constants';
+export const ADD_ITEM = 'qgo/assessment/ADD_ITEM';
+
+export const addItem = content => {
+  return { type: ADD_ITEM, content };
+};
 
 export const initialState = {
   items: [

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import reducer from '../logic/reducer';
+import reducer from '../logic/todos';
 
 export default function createReducer() {
   return combineReducers({


### PR DESCRIPTION
Use the ducks pattern for managing Redux boilerplate.

The main idea is to locate action types, actions, and reducers in the same file.

https://github.com/erikras/ducks-modular-redux

A number of candidates have mentioned that they would have preferred to have the organised the Redux code using the ducks pattern as it helps to keep related code together. I tend to agree with them so I've tidied up the existing code to follow this pattern.